### PR TITLE
Fix transparency range bug

### DIFF
--- a/abstracter
+++ b/abstracter
@@ -975,6 +975,8 @@ class AbstractArtGenerator(QMainWindow):
                 if self.alpha_checkbox.isChecked():
                     min_alpha = self.min_alpha_slider.value()
                     max_alpha = self.max_alpha_slider.value()
+                    if min_alpha > max_alpha:
+                        min_alpha, max_alpha = max_alpha, min_alpha
                     alpha = random.randint(min_alpha, max_alpha)
                     color.setAlpha(alpha)
                 else:


### PR DESCRIPTION
## Summary
- adjust alpha range computation to swap min/max when needed

## Testing
- `python -m py_compile abstracter`

------
https://chatgpt.com/codex/tasks/task_e_684df4a3d5b0832e90569d648a9b5dd5